### PR TITLE
Illustrate caching issue

### DIFF
--- a/example/source/Compound.svelte
+++ b/example/source/Compound.svelte
@@ -1,0 +1,8 @@
+<script>
+	import Sample from './Sample.svelte';
+</script>
+
+<Sample />
+<button type="button">
+	<slot />
+</button>

--- a/example/test/Compound.spec.js
+++ b/example/test/Compound.spec.js
@@ -1,0 +1,16 @@
+import { tick } from 'svelte';
+import Compound from '../source/Compound.svelte';
+
+test('has a button and the Sample', (done) => {
+	//  create a new element
+	const target = document.createElement('div');
+	//  render the component in the new element
+	const sample = new Compound({ target });
+
+	tick().then(() => {
+		expect(target.querySelector('button')).toBeTruthy();
+		expect(target.querySelector('[data-clicks="0"]')).toBeTruthy();
+
+		done();
+	});
+});


### PR DESCRIPTION
This is more of an issue report but with a full example to better illustrate the issue.

Have you given some thought to how we force `jest` to run the transformer again on every file that is affected by a change?

Imagine this case:
- Given `Compound.svelte` which imports `Sample.svelte`
- If I change something in `Sample.svelte` that affects how `Compound.svelte` behaves and therefore changes actual values in `Compound.spec.js` `jest` will only re-transform `Sample.svelte`. This means `Compound.svelte` will still return the same test result.
- You can try this by checking out this branch and 
  1. run `jest` (fills transform cache, passes)
  2. change the initial value of  `clicks` in `Sample.svelte` to `1`
  3. run `jest` again and now only `Sample.svelte` will fail while `Compound.svelte` still passes
  4. run `yarn jest --clearCache`
  5. run `yarn test` and now both cases will fail

`jest --no-cache` does only work if you run it on all tests. Once you add a pattern to it or let it run only on changed files we observe the same behavior as with cache.

It is not an issue with jest not re-running. If I only run `Compound.spec.js` it will still re-run if I make changes to `Sample.svelte`.