### PR TITLE
Make noStyles work also without preprocessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const process = (options = {}) => (source, filename) => {
 
 		deasync.loopWhile(() => !preprocessed);
 	} else {
-		preprocessed = source;
+		preprocessed = normalized;
 	}
 
 	const compiled = svelte.compile(preprocessed, {


### PR DESCRIPTION
Hi. Thanks for a nice project!

I have some problems with deasync (I think), it just hangs forever when using a preprocessor. But I only need preprocessing for styles, and just removing the styles would work.

However because of what I think might be a small bug, `noStyles` when there are no preprocessors. This PR fixes that.